### PR TITLE
[Revert] quick start version download to 0.5.0 until 0.5.1 is available

### DIFF
--- a/website/quick-start.sh
+++ b/website/quick-start.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Variables
-# Lucenia version defaults to 0.5.1 unless specified by environment variable
-LUCENIA_VERSION="${LUCENIA_VERSION:-0.5.1}"
+# Lucenia version defaults to 0.5.0 unless specified by environment variable
+LUCENIA_VERSION="${LUCENIA_VERSION:-0.5.0}"
 LUCENIA_HOME="$HOME/.lucenia"
 LUCENIA_INITIAL_ADMIN_PASSWORD="myStrongPassword@123"
 LUCENIA_SEC_TOOLS="$LUCENIA_HOME/lucenia-$LUCENIA_VERSION/plugins/lucenia-security/tools"


### PR DESCRIPTION
This reverts the quickstart downloaded version to 0.5.0 until the 0.5.1 artifacts are made available on digital ocean or we switch the quickstart resource to download from the S3 download bucket as is used on the downloads page.